### PR TITLE
API Add dev:build command and flushing capatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,27 @@ Ensure your composer's `bin` folder has been added to your system path.
 
 ## Usage
 
-### Menu
+### Commands
 
-To show the console menu, run `ssconsole` from your terminal.
+To show the console menu and list of commands, run `ssconsole` from your terminal.
 
 ### Running commands
 
 To run a command, choose the desired command from the menu and add it as an argument:
 
 ```shell
+# Runs a task
 ssconsole dev:tasks:CleanupTestDatabasesTask
+
+# Builds the database and flushed the manifest/cache
+ssconsole dev:build --flush
 ```
+
+### Flushing the manifest
+
+Sometimes you need to flush SilverStripe's manifest/cache while running CLI tasks. For example, if you've added a new `BuildTask`, but it doesn't show up in the SilverStripe console yet.
+
+You can add the `--flush` option to any `ssconsole` command to instruct SilverStripe to flush and rebuild its manifest.
 
 ## License
 

--- a/console.yml
+++ b/console.yml
@@ -7,6 +7,7 @@
 #
 
 Commands:
+  - SilverLeague\Console\Command\Dev\BuildCommand
   - SilverLeague\Console\Command\Member\ChangeGroupsCommand
   - SilverLeague\Console\Command\Member\ChangePasswordCommand
   - SilverLeague\Console\Command\Member\CreateCommand

--- a/src/Command/Dev/BuildCommand.php
+++ b/src/Command/Dev/BuildCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SilverLeague\Console\Command\Dev;
+
+use SilverLeague\Console\Command\SilverStripeCommand;
+use SilverStripe\ORM\DatabaseAdmin;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * The BuildCommand will trigger SilverStripe's database rebuild operation
+ *
+ * @package silverstripe-console
+ * @author  Robbie Averill <robbie@averill.co.nz>
+ */
+class BuildCommand extends SilverStripeCommand
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('dev:build')
+            ->setDescription('Builds the SilverStripe database');
+    }
+
+    /**
+     * {@inheritDoc}
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        (new DatabaseAdmin)->build();
+    }
+}

--- a/src/Framework/Scaffold.php
+++ b/src/Framework/Scaffold.php
@@ -60,6 +60,11 @@ NAME;
     {
         parent::__construct(new Application);
 
+        // Handle native SilverStripe flushing
+        if (in_array('--flush', $_SERVER['argv'])) {
+            $_GET['flush'] = 1;
+        }
+
         $this->bootstrap();
         $this->setSilverStripeLoader(new SilverStripeLoader($this->getApplication()));
         $this->setConfigurationLoader(new ConfigurationLoader($this->getApplication()));
@@ -176,6 +181,18 @@ NAME;
             )
         );
 
+        $this->addCommands();
+
+        return $this;
+    }
+
+    /**
+     * Adds all automatically created BuildTask Commands, and all concrete Commands from configuration
+     *
+     * @return self
+     */
+    protected function addCommands()
+    {
         foreach ($this->getSilverStripeLoader()->getTasks() as $command) {
             $this->getApplication()->add($command);
         }


### PR DESCRIPTION
The flushing system is not ideal in my opinion. The alternative at this stage in the framework would be to duplicate a larger amount of SilverStripe core code, so until the framework doesn't check `$_GET` for the flush key any more, this will do.

Resolves #9 
