### PR TITLE
API: Add config:dump and config:get commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ composer global require silverleague/silverstripe-console
 
 Ensure your composer's `bin` folder has been added to your system path.
 
+You can still require this module as a project dependency if you don't want to install it globally, of course.
+
 ### From source
 
 If you wish to install this module from source, you can clone the repository and symlink `bin/ssconsole` into your system path, for example:

--- a/console.yml
+++ b/console.yml
@@ -7,6 +7,7 @@
 #
 
 Commands:
+  - SilverLeague\Console\Command\Config\DumpCommand
   - SilverLeague\Console\Command\Dev\BuildCommand
   - SilverLeague\Console\Command\Member\ChangeGroupsCommand
   - SilverLeague\Console\Command\Member\ChangePasswordCommand

--- a/console.yml
+++ b/console.yml
@@ -8,6 +8,7 @@
 
 Commands:
   - SilverLeague\Console\Command\Config\DumpCommand
+  - SilverLeague\Console\Command\Config\GetCommand
   - SilverLeague\Console\Command\Dev\BuildCommand
   - SilverLeague\Console\Command\Member\ChangeGroupsCommand
   - SilverLeague\Console\Command\Member\ChangePasswordCommand

--- a/src/Command/Config/AbstractConfigCommand.php
+++ b/src/Command/Config/AbstractConfigCommand.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace SilverLeague\Console\Command\Config;
+
+use SilverLeague\Console\Command\SilverStripeCommand;
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Object;
+
+/**
+ * Provide base functionality for retrieving configuration from SilverStripe
+ *
+ * @package silverstripe-console
+ * @author  Robbie Averill <robbie@averill.co.nz>
+ */
+class AbstractConfigCommand extends SilverStripeCommand
+{
+    /**
+     * @var array
+     */
+    protected $yamlConfig;
+
+    /**
+     * @var \SilverStripe\Core\Manifest\ConfigManifest
+     */
+    protected $configManifest;
+
+    /**
+     * Gets the parsed YAML configuration array from the ConfigManifest
+     *
+     * @return array
+     */
+    public function getYamlConfig()
+    {
+        if ($this->yamlConfig === null) {
+            $manifest = $this->getConfigManifest();
+            $this->yamlConfig = $this->getPropertyValue($manifest, 'yamlConfig');
+        }
+        return $this->yamlConfig;
+    }
+
+    /**
+     * Assemble a data-set that would be returned from ConfigStaticManifest, if it were a bit more
+     * useful for external API access.
+     *
+     * @return array
+     */
+    public function getStaticConfig()
+    {
+        $output = [];
+        foreach (ClassInfo::subclassesFor(Object::class) as $class => $filename) {
+            $classConfig = [];
+            $reflection = new \ReflectionClass($class);
+            foreach ($reflection->getProperties() as $property) {
+                /** @var ReflectionProperty $property */
+                if ($property->isPrivate() && $property->isStatic()) {
+                    $property->setAccessible(true);
+                    $classConfig[$property->getName()] = $property->getValue();
+                }
+            }
+            if (!empty($classConfig)) {
+                $output[$class] = $classConfig;
+            }
+        }
+        return $output;
+    }
+
+    /**
+     * Gets the ConfigManifest from the current Config instance
+     *
+     * @return \SilverStripe\Core\Manifest\ConfigManifest
+     */
+    public function getConfigManifest()
+    {
+        if ($this->configManifest === null) {
+            $manifests = $this->getPropertyValue($this->getConfig(), 'manifests');
+            $this->configManifest = array_shift($manifests);
+        }
+        return $this->configManifest;
+    }
+
+    /**
+     * Gets any overrides made to the manifest
+     *
+     * @return array
+     */
+    public function getConfigOverrides()
+    {
+        $overrides = (array) $this->getPropertyValue($this->getConfig(), 'overrides');
+        return !empty($overrides) ? array_shift($overrides) : [];
+    }
+
+    /**
+     * Get the SilverStripe Config model
+     *
+     * @return Config
+     */
+    public function getConfig()
+    {
+        return Config::inst();
+    }
+
+    /**
+     * Gets the value of a non-public property from the given class instance
+     *
+     * @param  object $class
+     * @param  string $propertyName
+     * @return mixed
+     */
+    protected function getPropertyValue($class, $propertyName)
+    {
+        $reflectionClass = new \ReflectionClass($class);
+        $property = $reflectionClass->getProperty($propertyName);
+        $property->setAccessible(true);
+        return $property->getValue($class);
+    }
+}

--- a/src/Command/Config/DumpCommand.php
+++ b/src/Command/Config/DumpCommand.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace SilverLeague\Console\Command\Config;
+
+use SilverLeague\Console\Command\Config\AbstractConfigCommand;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Outputs a combined representation of all SilverStripe configuration
+ *
+ * @package silverstripe-console
+ * @author  Robbie Averill <robbie@averill.co.nz>
+ */
+class DumpCommand extends AbstractConfigCommand
+{
+    /**
+     * The supported configuration sources
+     *
+     * @var array
+     */
+    protected $configTypes = ['all', 'yaml', 'static', 'overrides'];
+
+    /**
+     * @var string
+     */
+    protected $configType;
+
+    /**
+     * @var string|null
+     */
+    protected $filter;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('config:dump')
+            ->setDescription('Dumps all of the processed configuration properties and their values')
+            ->addArgument('type', null, implode(', ', $this->configTypes), 'all')
+            ->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter the results (search)');
+
+        $this->setHelp(<<<HELP
+Dumps all of the processed configuration properties and their values. You can optionally filter the type to
+control the source of data, for example use "yaml" to only return configuration values that were defined in
+YAML configuration files. You can also add the --filter option with a search value to narrow the results.
+HELP
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @throws InvalidArgumentException If an invalid configuration type is provided
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($input->getArgument('type') && !in_array($input->getArgument('type'), $this->configTypes)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    '%s is not a valid config type, options: %s',
+                    $input->getArgument('type'),
+                    implode(', ', $this->configTypes)
+                )
+            );
+        }
+
+        $this->filter = $input->getOption('filter');
+        $this->configType = $input->getArgument('type');
+
+        $data = $this->getParsedOutput();
+        if ($this->filter) {
+            $data = $this->filterOutput($data, $this->filter);
+        }
+
+        $table = new Table($output);
+        $table
+            ->setHeaders(['Class name', 'Property', 'Key', 'Value'])
+            ->setRows($data)
+            ->render();
+    }
+
+    /**
+     * Get source configuration data by the optional "type"
+     *
+     * @return array
+     */
+    protected function getSourceData()
+    {
+        switch ($this->configType) {
+            case 'yaml':
+                $output = $this->getYamlConfig();
+                break;
+            case 'static':
+                $output = $this->getStaticConfig();
+                break;
+            case 'overrides':
+                $output = $this->getConfigOverrides();
+                break;
+            case 'all':
+            default:
+                $output = $this->getMergedData();
+                break;
+        }
+        return $output;
+    }
+
+    /**
+     * Merge together the config manifests data in the same manner as \SilverStripe\Core\Config\Config::getUncached
+     *
+     * @return array
+     */
+    protected function getMergedData()
+    {
+        // Statics are the lowest priority
+        $output = $this->getStaticConfig();
+
+        // Then YAML is added
+        foreach ($this->getYamlConfig() as $class => $property) {
+            if (!array_key_exists($class, $output)) {
+                $output[$class] = [];
+            }
+            $output[$class] = array_merge($property, $output[$class]);
+        }
+
+        // Then overrides are added last
+        foreach ($this->getConfigOverrides() as $class => $values) {
+            foreach ($values as $property => $value) {
+                $output[$class][$property] = $value;
+            }
+        }
+
+        return $output;
+    }
+
+    /**
+     * Creates a table-friendly output array from the input configuration sources
+     *
+     * @return array
+     */
+    protected function getParsedOutput()
+    {
+        $output = [];
+        foreach ($this->getSourceData() as $className => $classInfo) {
+            foreach ($classInfo as $property => $values) {
+                $row = [$className, $property];
+                if (is_array($values)) {
+                    foreach ($values as $key => $value) {
+                        $row[] = is_numeric($key) ? '' : $key;
+                        $row[] = is_array($value) ? json_encode($value, JSON_PRETTY_PRINT) : $value;
+                        $output[] = $row;
+                        // We need the class and property data for second level values if we're filtering.
+                        if ($this->filter !== null) {
+                            $row = [$className, $property];
+                        } else {
+                            $row = ['', ''];
+                        }
+                    }
+                } else {
+                    $row[] = '';
+                    $row[] = $values;
+                }
+                $output[] = $row;
+            }
+        }
+        return $output;
+    }
+
+    /**
+     * Apply a search filter to the results
+     *
+     * @param  array  $data   The pre-parsed output data
+     * @param  string $filter The string to search on
+     * @return array          Rows that have a string match on any of their fields
+     */
+    protected function filterOutput($data, $filter)
+    {
+        $output = [];
+        foreach ($data as $values) {
+            foreach ($values as $value) {
+                if (is_string($value) && stripos($value, $filter) !== false) {
+                    $output[] = $values;
+                }
+            }
+        }
+        return $output;
+    }
+}

--- a/src/Command/Config/GetCommand.php
+++ b/src/Command/Config/GetCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SilverLeague\Console\Command\Config;
+
+use SilverLeague\Console\Command\Config\AbstractConfigCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Lookup configuration settings by class and property name
+ *
+ * @package silverstripe-console
+ * @author  Robbie Averill <robbie@averill.co.nz>
+ */
+class GetCommand extends AbstractConfigCommand
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('config:get')
+            ->setDescription('Look up a specific configuration value')
+            ->addArgument('class', InputArgument::REQUIRED)
+            ->addArgument('property', InputArgument::REQUIRED);
+
+        $this->setHelp(<<<HELP
+Look up a specific configuration value and output it directly. This command can be used for build processes,
+automated scripts, quick checks etc where raw output is required outside of the SilverStripe application.
+HELP
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $result = $this->getConfig()->get(
+            $input->getArgument('class'),
+            $input->getArgument('property')
+        );
+        $output->writeln(var_export($result, true));
+    }
+}

--- a/tests/Command/AbstractCommandTest.php
+++ b/tests/Command/AbstractCommandTest.php
@@ -41,7 +41,7 @@ abstract class AbstractCommandTest extends \PHPUnit_Framework_TestCase
      * @param  array $params
      * @return CommandTester
      */
-    protected function executeTest(array $params)
+    protected function executeTest(array $params = [])
     {
         $tester = new CommandTester($this->command);
         $tester->execute($params);

--- a/tests/Command/Config/DumpCommandTest.php
+++ b/tests/Command/Config/DumpCommandTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace SilverLeague\Console\Tests\Command\Config;
+
+use SilverLeague\Console\Tests\Command\AbstractCommandTest;
+use SilverStripe\Core\Config\Config;
+
+/**
+ * @coversDefaultClass \SilverLeague\Console\Command\Config\DumpCommand
+ * @package silverstripe-console
+ * @author  Robbie Averill <robbie@averill.co.nz>
+ */
+class DumpCommandTest extends AbstractCommandTest
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function getTestCommand()
+    {
+        return 'config:dump';
+    }
+
+    /**
+     * Ensure that the InputOptions exist
+     *
+     * @covers ::configure
+     */
+    public function testConfigure()
+    {
+        $this->assertTrue($this->command->getDefinition()->hasArgument('type'));
+        $this->assertTrue($this->command->getDefinition()->hasOption('filter'));
+    }
+
+    /**
+     * Ensure that passing an invalid "type" argument throws an exception
+     *
+     * @covers ::execute
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage foo is not a valid config type, options: all, yaml, static, overrides
+     */
+    public function testInvalidTypeThrowsException()
+    {
+        $this->executeTest(['type' => 'foo']);
+    }
+
+    /**
+     * Test that the command can successfully be executed
+     *
+     * @covers ::execute
+     */
+    public function testExecute()
+    {
+        $result = $this->executeTest()->getDisplay();
+        $this->assertContains('SilverStripe\\Control\\Director', $result);
+        $this->assertContains('SilverStripe\\Core\\Injector\\Injector', $result);
+    }
+
+    /**
+     * Test that the results can be filtered
+     *
+     * @covers ::execute
+     * @covers ::filterOutput
+     */
+    public function testExecuteWithFilteredResults()
+    {
+        $result = $this->executeTest(['--filter' => 'SilverStripe\\Control\\Director'])->getDisplay();
+        $this->assertContains('SilverStripe\\Control\\Director', $result);
+        $this->assertNotContains('SilverStripe\\Core\\Injector\\Injector', $result);
+    }
+
+    /**
+     * Ensure that the filter is applied to any column of the data
+     *
+     * @covers ::filterOutput
+     */
+    public function testFilterOnAnyColumn()
+    {
+        $result = $this->executeTest(['--filter' => '%$DisplayErrorHandler'])->getDisplay();
+        $this->assertContains('pushHandler', $result);
+
+        $result = $this->executeTest(['--filter' => 'pushHandler'])->getDisplay();
+        $this->assertContains('%$DisplayErrorHandler', $result);
+    }
+
+    /**
+     * Test that the source data can be set to YAML, static, overrides or "all"
+     *
+     * @covers \SilverLeague\Console\Command\Config\AbstractConfigCommand::getConfig
+     * @covers \SilverLeague\Console\Command\Config\AbstractConfigCommand::getPropertyValue
+     * @covers \SilverLeague\Console\Command\Config\AbstractConfigCommand::getStaticConfig
+     * @covers \SilverLeague\Console\Command\Config\AbstractConfigCommand::getConfigOverrides
+     * @covers \SilverLeague\Console\Command\Config\AbstractConfigCommand::getYamlConfig
+     * @covers ::getMergedData
+     */
+    public function testAllDataContainsBothYamlAndStatic()
+    {
+        Config::inst()->update('Gorilla', 'warfare', 'magpie fairy bread');
+        $result = $this->executeTest(['type' => 'all'])->getDisplay();
+        $this->assertContains('has_one', $result);
+        $this->assertContains('%$DisplayErrorHandler', $result);
+        $this->assertContains('magpie fairy bread', $result);
+    }
+
+    /**
+     * Ensure that the configuration source can be set to only YAML file data
+     *
+     * @covers \SilverLeague\Console\Command\Config\AbstractConfigCommand::getYamlConfig
+     */
+    public function testGetOnlyYamlConfiguration()
+    {
+        $result = $this->executeTest(['type' => 'yaml'])->getDisplay();
+        $this->assertNotContains('has_one', $result);
+        $this->assertContains('%$DisplayErrorHandler', $result);
+    }
+
+    /**
+     * Ensure that the configuration source can be set to only private statics
+     *
+     * @covers \SilverLeague\Console\Command\Config\AbstractConfigCommand::getStaticConfig
+     */
+    public function testGetOnlyStaticConfiguration()
+    {
+        $result = $this->executeTest(['type' => 'static'])->getDisplay();
+        $this->assertContains('has_one', $result);
+        $this->assertNotContains('%$DisplayErrorHandler', $result);
+    }
+
+    /**
+     * Test that override configuration only can be returned
+     *
+     * @covers \SilverLeague\Console\Command\Config\AbstractConfigCommand::getConfigOverrides
+     */
+    public function testGetOnlyOverrideConfiguration()
+    {
+        Config::inst()->update('Bookcase', 'dresser', 'drawers');
+        $result = $this->executeTest(['type' => 'overrides'])->getDisplay();
+        $this->assertContains('Bookcase', $result);
+        $this->assertNotContains('Injector', $result);
+    }
+
+    /**
+     * Test that the "all" type is treated the same as not providing one (i.e. default)
+     *
+     * @covers ::getSourceData
+     */
+    public function testAllIsDefaultType()
+    {
+        $typeAll = $this->executeTest(['type' => 'all'])->getDisplay();
+        $typeNone = $this->executeTest()->getDisplay();
+
+        $this->assertSame($typeAll, $typeNone);
+    }
+
+    /**
+     * Ensure that numeric property keys are replaced with nada
+     *
+     * @covers ::getParsedOutput
+     */
+    public function testNumericKeysAreNotShown()
+    {
+        Config::inst()->update('FooBar', 'my_property', [1 => 'baz', 'bar' => 'banter']);
+        $result = $this->executeTest(['type' => 'overrides', '--filter' => 'FooBar'])->getDisplay();
+        $this->assertNotContains('1', $result);
+        $this->assertContains('bar', $result);
+    }
+
+    /**
+     * Ensure that nested array values for properties are displayed as JSON. Since it crosses multiple lines,
+     * we can't assert it exactly.
+     *
+     * @covers ::getParsedOutput
+     */
+    public function testNestedArrayValuesAreDisplayedAsJson()
+    {
+        $input = ['brands' => ['good' => 'Heatings R Us', 'great' => 'Never-B-Cold', 'best' => 'Luv-Fyre']];
+        Config::inst()->update('HeatingSupplies', 'brands', $input);
+        $result = $this->executeTest()->getDisplay();
+        $this->assertContains('"great": "Never-B-Cold",', $result);
+    }
+
+    /**
+     * While this behaviour is not desireable, it is what it is. For now, test that the private statics
+     * are gathered from children of Object only.
+     *
+     * @covers \SilverLeague\Console\Command\Config\AbstractConfigCommand::getStaticConfig
+     */
+    public function testFindStaticsForSubclassesOfObjectOnly()
+    {
+        $result = $this->executeTest(['type' => 'static'])->getDisplay();
+        $this->assertNotContains(
+            'Injector',
+            $result,
+            'Injector has a private static property, but does not extend Object - should not be displayed'
+        );
+        $this->assertContains('SilverStripe\\ORM\\DataObject', $result, 'DataObject should definitely be displayed.');
+    }
+
+    /**
+     * Ensure that the ConfigManifest is returned
+     *
+     * @covers \SilverLeague\Console\Command\Config\AbstractConfigCommand::getConfigManifest
+     */
+    public function testGetConfigManifest()
+    {
+        $result = $this->command->getConfigManifest();
+        $this->assertInstanceOf('SilverStripe\\Core\\Manifest\\ConfigManifest', $result);
+    }
+}

--- a/tests/Command/Config/GetCommandTest.php
+++ b/tests/Command/Config/GetCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace SilverLeague\Console\Tests\Command\Config;
+
+use SilverLeague\Console\Tests\Command\AbstractCommandTest;
+use SilverStripe\Core\Config\Config;
+
+/**
+ * @coversDefaultClass \SilverLeague\Console\Command\Config\GetCommand
+ * @package silverstripe-console
+ * @author  Robbie Averill <robbie@averill.co.nz>
+ */
+class GetCommandTest extends AbstractCommandTest
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function getTestCommand()
+    {
+        return 'config:get';
+    }
+
+    /**
+     * Ensure that the class and property arguments are required
+     *
+     * @covers ::configure
+     */
+    public function testConfigure()
+    {
+        $this->assertTrue($this->command->getDefinition()->getArgument('class')->isRequired());
+        $this->assertTrue($this->command->getDefinition()->getArgument('property')->isRequired());
+    }
+
+    /**
+     * Ensure a successful execution returns the value of the config property
+     *
+     * @covers ::execute
+     */
+    public function testExecute()
+    {
+        Config::inst()->update('space', 'monkey_hater_machine', 'donkey');
+        $result = $this->executeTest(['class' => 'space', 'property' => 'monkey_hater_machine'])->getDisplay();
+        $this->assertContains('donkey', $result);
+    }
+
+    /**
+     * Ensure that null is returned for a non-existent value
+     *
+     * @covers ::execute
+     */
+    public function testNonExistentValue()
+    {
+        $result = $this->executeTest(['class' => 'Moegli', 'property' => 'penny_farthing'])->getDisplay();
+        $this->assertContains('NULL', $result);
+    }
+}

--- a/tests/Command/Member/ChangeGroupsCommandTest.php
+++ b/tests/Command/Member/ChangeGroupsCommandTest.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 /**
  * Change a member's assigned groups
  *
+ * @coversDefaultClass \SilverLeague\Console\Command\Member\ChangeGroupsCommand
  * @package silverstripe-console
  * @author  Robbie Averill <robbie@averill.co.nz>
  */


### PR DESCRIPTION
`config:get` will retrieve a specific configuration value and output it via `var_export`.

`config:dump` will merge configuration from overrides, YAML and statics and output them in a table with their class, property and values. You can filter it by config type and with a string search.

Resolves #3 