### PR TITLE
Add SilverStripe 4.3 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
     - php: 7.1
       env: DB=MYSQL RECIPE_VERSION=4.2.x-dev
     - php: 7.2
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev
+    - php: 7.2
       env: DB=MYSQL RECIPE_VERSION=4.x-dev
 
 before_install:


### PR DESCRIPTION
4.3.0-rc1 was released last week - this will ensure we test against it